### PR TITLE
Feat/flint system -> rebase_upstream

### DIFF
--- a/Content.Server/Civ14/Crafting/KnappingSystem.cs
+++ b/Content.Server/Civ14/Crafting/KnappingSystem.cs
@@ -1,0 +1,54 @@
+using Content.Server.DoAfter;
+using Content.Shared.Rocks;
+using Content.Shared.Interaction;
+using Content.Shared.DoAfter;
+using Robust.Server.GameObjects;
+using Content.Shared.Popups;
+using Content.Shared.Hands.EntitySystems;
+
+namespace Content.Server.Rocks;
+
+public sealed partial class KnappingSystem : EntitySystem
+{
+    [Dependency] private readonly DoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<KnappingComponent, AfterInteractEvent>(OnAfterInteract);
+        SubscribeLocalEvent<KnappingComponent, KnappingDoAfterEvent>(OnDoAfter);
+    }
+
+    private void OnAfterInteract(EntityUid uid, KnappingComponent component, AfterInteractEvent args)
+    {
+        if (args.Target == null || !args.CanReach || !HasComp<KnappingAnchoredComponent>(args.Target))
+            return;
+
+        _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, component.HitTime, new KnappingDoAfterEvent(), uid, target: args.Target, used: uid)
+        {
+            Broadcast = true,
+            BreakOnMove = true,
+            NeedHand = true,
+        });
+    }
+
+    private void OnDoAfter(EntityUid flintUid, KnappingComponent component, ref KnappingDoAfterEvent args)
+    {
+
+        if (args.Cancelled || args.Handled)
+            return;
+
+        component.CurrentHits++;
+
+        if (component.CurrentHits >= component.HitsRequired)
+        {
+            var result = Spawn(component.ResultPrototype, Transform(flintUid).MapPosition);
+            QueueDel(flintUid);
+            _hands.TryPickupAnyHand(args.Args.User, result);
+        }
+
+        args.Handled = true;
+    }
+}

--- a/Content.Server/Civ14/Rocks/FlintRockSystem.cs
+++ b/Content.Server/Civ14/Rocks/FlintRockSystem.cs
@@ -32,7 +32,7 @@ public sealed partial class FlintRockSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, FlintRockComponent component, MapInitEvent args)
     {
-        component.CurrentFlints = Random.Next(1, component.MaxFlints + 1);
+        component.CurrentFlints = Random.Next(0, component.MaxFlints + 1);
     }
 
     public override void Update(float frameTime)

--- a/Content.Server/Civ14/Rocks/FlintRockSystem.cs
+++ b/Content.Server/Civ14/Rocks/FlintRockSystem.cs
@@ -1,0 +1,111 @@
+using Content.Server.DoAfter;
+using Content.Shared.Rocks;
+using Content.Shared.Interaction;
+using Content.Shared.DoAfter;
+using Robust.Server.GameObjects;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+using Content.Shared.Popups;
+using Content.Shared.Verbs;
+using Content.Shared.Examine;
+using Content.Shared.Hands.EntitySystems;
+
+namespace Content.Server.Rocks;
+
+public sealed partial class FlintRockSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom Random = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly DoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedHandsSystem _hands = default!;
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<FlintRockComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<FlintRockComponent, CollectFlintDoAfterEvent>(OnDoAfter);
+        SubscribeLocalEvent<FlintRockComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+        SubscribeLocalEvent<FlintRockComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnMapInit(EntityUid uid, FlintRockComponent component, MapInitEvent args)
+    {
+        component.CurrentFlints = Random.Next(1, component.MaxFlints + 1);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<FlintRockComponent>();
+        while (query.MoveNext(out var uid, out var component))
+        {
+            var currentTime = _gameTiming.CurTime;
+            if (currentTime >= component.LastRegenerationTime + TimeSpan.FromHours(component.RegenerationTime))
+            {
+                if (component.CurrentFlints < component.MaxFlints)
+                {
+                    component.CurrentFlints++;
+                    component.LastRegenerationTime = currentTime;
+                }
+            }
+        }
+    }
+
+    private void OnGetVerbs(EntityUid uid, FlintRockComponent component, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract || component.CurrentFlints <= 0)
+            return;
+
+        var user = args.User;
+
+        var verb = new AlternativeVerb
+        {
+            Text = "Collect Flint",
+            Act = () => StartCollectingFlint(uid, component, user)
+        };
+        args.Verbs.Add(verb);
+    }
+
+    private void StartCollectingFlint(EntityUid rockUid, FlintRockComponent component, EntityUid user)
+    {
+        var doAfterArgs = new DoAfterArgs(EntityManager, user, component.CollectionTime, new CollectFlintDoAfterEvent(), rockUid)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+            NeedHand = true
+        };
+
+        _doAfter.TryStartDoAfter(doAfterArgs);
+    }
+
+    private void OnDoAfter(EntityUid uid, FlintRockComponent component, ref CollectFlintDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        component.CurrentFlints--;
+        var spawnPos = Transform(uid).MapPosition;
+        var flint = Spawn("Flint", spawnPos);
+        _hands.TryPickupAnyHand(args.Args.User, flint);
+        _popup.PopupEntity("You successfully collect a flint.", uid, args.Args.User);
+        args.Handled = true;
+    }
+
+    private void OnExamined(EntityUid uid, FlintRockComponent component, ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        var flintCount = component.CurrentFlints;
+        if (flintCount > 0)
+        {
+            var message = flintCount == 1
+                ? "A single piece of flint is partially exposed in the rock."
+                : $"There are {flintCount} loose pieces of flint in the rock.";
+            args.PushMarkup(message);
+        }
+    }
+}

--- a/Content.Shared/Civ14/Crafting/KnappingAnchoredComponent.cs
+++ b/Content.Shared/Civ14/Crafting/KnappingAnchoredComponent.cs
@@ -1,0 +1,6 @@
+namespace Content.Shared.Rocks;
+
+[RegisterComponent]
+public sealed partial class KnappingAnchoredComponent : Component
+{
+}

--- a/Content.Shared/Civ14/Crafting/KnappingComponent.cs
+++ b/Content.Shared/Civ14/Crafting/KnappingComponent.cs
@@ -1,0 +1,37 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Rocks;
+
+[RegisterComponent]
+public sealed partial class KnappingComponent : Component
+{
+    /// <summary>
+    /// Amount of hits needed to complete the craft
+    /// </summary>
+    [DataField("hitsRequired")]
+    public int HitsRequired = 3;
+
+    /// <summary>
+    /// Prototype that the knapping will result
+    /// </summary>
+    [DataField("resultPrototype")]
+    public string ResultPrototype = "SharpenedFlint";
+
+    /// <summary>
+    /// If true, allow the user to knap into a boulder. takes longer
+    /// </summary>
+    [DataField("allowRockKnapping")]
+    public bool AllowRockKnapping = true;
+
+    /// <summary>
+    /// time that each knapping hit takes
+    /// </summary>
+    [DataField("hitTime")]
+    public float HitTime = 2.0f;
+
+    /// <summary>
+    /// amount of hits already done
+    /// </summary>
+    [DataField("currentHits")]
+    public int CurrentHits = 0;
+}

--- a/Content.Shared/Civ14/Crafting/KnappingDoAfterEvent.cs
+++ b/Content.Shared/Civ14/Crafting/KnappingDoAfterEvent.cs
@@ -1,0 +1,10 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Rocks;
+
+[Serializable, NetSerializable]
+public sealed partial class KnappingDoAfterEvent : DoAfterEvent
+{
+    public override DoAfterEvent Clone() => this;
+}

--- a/Content.Shared/Civ14/Rocks/CollectFlintDoAfterEvent.cs
+++ b/Content.Shared/Civ14/Rocks/CollectFlintDoAfterEvent.cs
@@ -1,0 +1,9 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Rocks;
+
+[Serializable, NetSerializable]
+public sealed partial class CollectFlintDoAfterEvent : SimpleDoAfterEvent
+{
+}

--- a/Content.Shared/Civ14/Rocks/FlintRockComponent.cs
+++ b/Content.Shared/Civ14/Rocks/FlintRockComponent.cs
@@ -1,0 +1,37 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Rocks;
+
+[RegisterComponent]
+public sealed partial class FlintRockComponent : Component
+{
+    /// <summary>
+    /// Actual available flints amount
+    /// </summary>
+    [DataField("currentFlints")]
+    public int CurrentFlints = 0;
+
+    /// <summary>
+    /// Maximum flint amount on rock
+    /// </summary>
+    [DataField("maxFlints")]
+    public int MaxFlints = 2;
+
+    /// <summary>
+    /// Time in hours to create a new flint
+    /// </summary>
+    [DataField("regenerationTime")]
+    public float RegenerationTime = 1.0f; // 1 hora
+
+    /// <summary>
+    /// Last time that it regenerated a flint
+    /// </summary>
+    [DataField("lastRegenerationTime")]
+    public TimeSpan LastRegenerationTime = TimeSpan.Zero;
+
+    /// <summary>
+    /// The time taken to collect flint from a rock
+    /// </summary>
+    [DataField("collectionTime")]
+    public float CollectionTime { get; set; } = 5.0f;
+}

--- a/Resources/Prototypes/Civ14/Entities/Objects/Materials/Sheets/rock.yml
+++ b/Resources/Prototypes/Civ14/Entities/Objects/Materials/Sheets/rock.yml
@@ -1,0 +1,14 @@
+- type: entity
+  name: flint
+  parent: BaseItem
+  id: Flint
+  description: A small piece of flint, useful for crafting.
+  components:
+  - type: Sprite
+    netsync: false
+    sprite: Objects/_civ/old_weapons.rsi
+    state: flint
+  - type: Item
+    shape:
+    - 0,0,1,0
+    storedOffset: 0,-6

--- a/Resources/Prototypes/Civ14/Entities/Objects/Materials/Sheets/rock.yml
+++ b/Resources/Prototypes/Civ14/Entities/Objects/Materials/Sheets/rock.yml
@@ -12,3 +12,23 @@
     shape:
     - 0,0,1,0
     storedOffset: 0,-6
+  - type: Knapping
+    hitsRequired: 5
+    resultPrototype: SharpenedFlint
+    allowRockKnapping: true
+    hitTime: 2.0
+
+- type: entity
+  name: sharpened flint
+  parent: BaseItem
+  id: SharpenedFlint
+  description: A sharpened piece of flint, ready for use.
+  components:
+  - type: Sprite
+    netsync: false
+    sprite: Objects/_civ/old_weapons.rsi
+    state: sharpened_flint
+  - type: Item
+    shape:
+    - 0,0,1,0
+    storedOffset: 0,-6

--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -160,6 +160,9 @@
         rocksolid01: ""
         rocksolid02: ""
         rocksolid03: ""
+  - type: FlintRock
+    maxFlints: 2
+    regenerationTime: 1.0
 
 - type: entity
   name: stalagmite

--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -163,6 +163,7 @@
   - type: FlintRock
     maxFlints: 2
     regenerationTime: 1.0
+  - type: KnappingAnchored
 
 - type: entity
   name: stalagmite


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

This PR introduces two new components: FlintRockComponent and KnappingComponent.

Features Added

FlintRockComponent
- Added to the BaseRock entity.
- Rocks now spawn with 0 to 2 flints.
- A new flint becomes available every hour.

KnappingComponent
- Added to the flint entity.
- Players can now knap flint by striking it a required number of times.
- Once completed, the knapped flint is spawned and automatically picked up.

**Media**
![image](https://github.com/user-attachments/assets/009e7d04-a77d-4e6d-9b48-d0b8efff134b)

<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- add: Introduced FlintRock, allowing rocks to spawn with up to 2 flints.
- add: Implemented Knapping, enabling players to shape flint through repeated strikes.
- tweak: A new flint becomes available in rocks every hour.