### PR TITLE
Feat/wood straw harverst

### DIFF
--- a/Content.Server/Civ14/Gathering/StrawCollectorSystem.cs
+++ b/Content.Server/Civ14/Gathering/StrawCollectorSystem.cs
@@ -106,7 +106,7 @@ public sealed partial class StrawCollectorSystem : EntitySystem
             Spawn("MaterialStraw1", coordinates);
         }
 
-        _popup.PopupEntity($"You finish cutting the grass. DEBUG: {strawCount}", ent, args.User);
+        _popup.PopupEntity($"You finish cutting the grass.", ent, args.User);
         args.Handled = true;
     }
 }

--- a/Content.Server/Civ14/Gathering/StrawCollectorSystem.cs
+++ b/Content.Server/Civ14/Gathering/StrawCollectorSystem.cs
@@ -1,0 +1,112 @@
+using Content.Shared.Interaction;
+using Content.Shared.DoAfter;
+using Content.Server.DoAfter;
+using Content.Shared.Maps;
+using Content.Shared.Popups;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Random;
+using Content.Shared.Gathering;
+
+namespace Content.Server.Gathering;
+
+public sealed partial class StrawCollectorSystem : EntitySystem
+{
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly ITileDefinitionManager _tileManager = default!;
+    [Dependency] private readonly DoAfterSystem _doAfter = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    // Grass tiles that can be cut
+    private readonly HashSet<string> _grassTiles = new()
+    {
+        "FloorGrass",
+        "FloorGrassJungle",
+        "FloorGrassDark",
+        "FloorGrassLight",
+        "FloorAstroGrass",
+        "FloorPlanetGrass",
+        "FloorJungleAstroGrass",
+        "FloorMowedAstroGrass"
+    };
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<StrawCollectorComponent, AfterInteractEvent>(OnAfterInteract);
+        SubscribeLocalEvent<StrawCollectorComponent, StrawCollectDoAfterEvent>(OnDoAfter);
+    }
+
+    private void OnAfterInteract(Entity<StrawCollectorComponent> ent, ref AfterInteractEvent args)
+    {
+        if (args.Handled || args.Target != null || !args.CanReach)
+            return;
+
+        var comp = ent.Comp;
+        var user = args.User;
+        var clickLocation = args.ClickLocation;
+
+        var gridUid = _transform.GetGrid(clickLocation);
+        if (!gridUid.HasValue || !TryComp<MapGridComponent>(gridUid.Value, out var grid))
+            return;
+
+        var snapPos = grid.TileIndicesFor(clickLocation);
+        var tileRef = _map.GetTileRef(gridUid.Value, grid, snapPos);
+        var tileDef = (ContentTileDefinition)_tileManager[tileRef.Tile.TypeId];
+
+        if (!_grassTiles.Contains(tileDef.ID))
+        {
+            return;
+        }
+
+        var delay = TimeSpan.FromSeconds(comp.CollectTime);
+        var netGridUid = GetNetEntity(gridUid.Value);
+        var doAfterArgs = new DoAfterArgs(EntityManager, user, delay, new StrawCollectDoAfterEvent(netGridUid, snapPos), ent)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+            NeedHand = true
+        };
+
+        if (_doAfter.TryStartDoAfter(doAfterArgs))
+        {
+            _popup.PopupEntity("You begin cutting the grass.", ent, user);
+            args.Handled = true;
+        }
+    }
+
+    private void OnDoAfter(Entity<StrawCollectorComponent> ent, ref StrawCollectDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        var gridUid = GetEntity(args.GridUid);
+        if (!TryComp<MapGridComponent>(gridUid, out var grid))
+            return;
+
+        var snapPos = args.SnapPos;
+        var tileRef = _map.GetTileRef(gridUid, grid, snapPos);
+        var tileDef = (ContentTileDefinition)_tileManager[tileRef.Tile.TypeId];
+
+        if (!_grassTiles.Contains(tileDef.ID))
+        {
+            return; // Tile has changed, abort
+        }
+
+        var dirtTile = _tileManager["FloorDirt"];
+        _map.SetTile(gridUid, grid, snapPos, new Tile(dirtTile.TileId));
+
+        var comp = ent.Comp;
+        var strawCount = _random.Next(comp.MinAmount, comp.MaxAmount + 1);
+        var coordinates = grid.GridTileToLocal(snapPos);
+        for (int i = 0; i < strawCount; i++)
+        {
+            Spawn("MaterialStraw1", coordinates);
+        }
+
+        _popup.PopupEntity($"You finish cutting the grass. DEBUG: {strawCount}", ent, args.User);
+        args.Handled = true;
+    }
+}

--- a/Content.Shared/Civ14/Gathering/StrawCollectDoAfterEvent.cs
+++ b/Content.Shared/Civ14/Gathering/StrawCollectDoAfterEvent.cs
@@ -1,0 +1,20 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Gathering;
+
+[Serializable, NetSerializable]
+public sealed partial class StrawCollectDoAfterEvent : DoAfterEvent
+{
+    public NetEntity GridUid { get; }
+    public Vector2i SnapPos { get; }
+
+    public StrawCollectDoAfterEvent(NetEntity gridUid, Vector2i snapPos)
+    {
+        GridUid = gridUid;
+        SnapPos = snapPos;
+    }
+
+    public override DoAfterEvent Clone() => this;
+}

--- a/Content.Shared/Civ14/Gathering/StrawCollectorComponent.cs
+++ b/Content.Shared/Civ14/Gathering/StrawCollectorComponent.cs
@@ -1,0 +1,25 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Gathering;
+
+[RegisterComponent]
+public sealed partial class StrawCollectorComponent : Component
+{
+    /// <summary>
+    /// Time in seconds to collect straw
+    /// </summary>
+    [DataField]
+    public float CollectTime = 5.0f;
+
+    /// <summary>
+    /// Minimum amount harversted
+    /// </summary>
+    [DataField]
+    public int MinAmount = 0;
+
+    /// <summary>
+    /// Maximum amount harversted
+    /// </summary>
+    [DataField]
+    public int MaxAmount = 3;
+}

--- a/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/flora.yml
@@ -69,13 +69,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 400
+        damage: 300
       behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 50
+        damage: 200
       behaviors:
       - !type:PlaySoundBehavior
         sound:
@@ -88,8 +88,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           Log:
-            min: 2
-            max: 8
+            min: 1
+            max: 3
   - type: TreeBranches
 
 - type: entity
@@ -127,6 +127,31 @@
         density: 2000
         layer:
         - WallLayer
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 600
+      behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 400
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          path: /Audio/Effects/tree_fell.ogg
+          params:
+            volume: 5
+            variation: 0.05
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          Log:
+            min: 2
+            max: 6
 
 - type: entity
   parent: BaseTree

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -28,6 +28,10 @@
       useSound:
         path: /Audio/Items/Culinary/chop.ogg
     - type: SeedSlicer
+    - type: StrawCollector
+      collectTime: 5.0
+      minAmount: 0
+      maxAmount: 2
 
 - type: entity
   name: kitchen knife


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I balanced the health of the BaseTree and BaseTreeLarge, along with adjusting the amount of wood they drop when chopped. I also implemented the StrawCollector component, which interacts with grass tiles to collect straw.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://i.imgur.com/3TTQ2O0.mp4
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Balanced health and wood drops for BaseTree and BaseTreeLarge.
- add: Implemented StrawCollector component into knives for collecting straw from grass tiles
-->
