### PR TITLE
Factions top game bar button

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -135,6 +135,7 @@ namespace Content.Client.Input
             common.AddFunction(ContentKeyFunctions.OpenDecalSpawnWindow);
             common.AddFunction(ContentKeyFunctions.OpenAdminMenu);
             common.AddFunction(ContentKeyFunctions.OpenGuidebook);
+            common.AddFunction(ContentKeyFunctions.OpenFactionsMenu);
         }
     }
 }

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -216,6 +216,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.OpenCharacterMenu);
             AddButton(ContentKeyFunctions.OpenCraftingMenu);
             AddButton(ContentKeyFunctions.OpenGuidebook);
+            AddButton(ContentKeyFunctions.OpenFactionsMenu);
             AddButton(ContentKeyFunctions.OpenInventoryMenu);
             AddButton(ContentKeyFunctions.OpenAHelp);
             AddButton(ContentKeyFunctions.OpenActionsMenu);

--- a/Content.Client/UserInterface/Systems/MenuBar/Widgets/GameTopMenuBar.xaml
+++ b/Content.Client/UserInterface/Systems/MenuBar/Widgets/GameTopMenuBar.xaml
@@ -74,6 +74,16 @@
         AppendStyleClass="{x:Static style:StyleBase.ButtonSquare}"
         />
     <ui:MenuButton
+        Name="FactionButton"
+        Access="Internal"
+        Icon="{xe:Tex '/Textures/Interface/fist.svg.192dpi.png'}"
+        BoundKey = "{x:Static is:ContentKeyFunctions.OpenFactionsMenu}"
+        ToolTip="{Loc 'game-hud-open-factions-menu-button-tooltip'}"
+        MinSize="42 64"
+        HorizontalExpand="True"
+        AppendStyleClass="{x:Static style:StyleBase.ButtonSquare}"
+        />
+    <ui:MenuButton
         Name="AdminButton"
         Access="Internal"
         Icon="{xe:Tex '/Textures/Interface/gavel.svg.192dpi.png'}"

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -27,6 +27,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction OpenCharacterMenu = "OpenCharacterMenu";
         public static readonly BoundKeyFunction OpenEmotesMenu = "OpenEmotesMenu";
         public static readonly BoundKeyFunction OpenCraftingMenu = "OpenCraftingMenu";
+        public static readonly BoundKeyFunction OpenFactionsMenu = "OpenFactionsMenu";
         public static readonly BoundKeyFunction OpenGuidebook = "OpenGuidebook";
         public static readonly BoundKeyFunction OpenInventoryMenu = "OpenInventoryMenu";
         public static readonly BoundKeyFunction SmartEquipBackpack = "SmartEquipBackpack";

--- a/Resources/Locale/en-US/HUD/game-hud.ftl
+++ b/Resources/Locale/en-US/HUD/game-hud.ftl
@@ -5,5 +5,6 @@ game-hud-open-emotes-menu-button-tooltip= Open emotes menu.
 game-hud-open-inventory-menu-button-tooltip = Open inventory menu.
 game-hud-open-crafting-menu-button-tooltip = Open crafting menu.
 game-hud-open-actions-menu-button-tooltip = Open actions menu.
+game-hud-open-factions-menu-button-tooltip = Open factions menu.
 game-hud-open-admin-menu-button-tooltip = Open admin menu.
 game-hud-open-sandbox-menu-button-tooltip = Open sandbox menu.

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -234,6 +234,9 @@ binds:
   - function: OpenCraftingMenu
     type: State
     key: G
+  - function: OpenFactionsMenu
+    type: State
+    key: NumpadNum1
   - function: OpenGuidebook
     type: State
     key: NumpadNum0


### PR DESCRIPTION
## Changelog

Adds factions top game bar button. 
Only do linking and UI

_(uses fist.svg.192dpi.png as the icon for the button, ask someone to make the appropriate vector icon for the button)_